### PR TITLE
Fix missing AES util

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "index.ts"
   ],
   "include": [
-    "lib/**/*.ts"
+    "lib/**/*.ts",
+    "lib/util/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
When installing this the `dist/util` folder is missing.